### PR TITLE
Kalenderposisjon

### DIFF
--- a/src/components/sporsmal/AvbrytDialog.tsx
+++ b/src/components/sporsmal/AvbrytDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PanelBase from 'nav-frontend-paneler';
 import Tekstomrade from 'nav-frontend-tekstomrade';
 import tekster from './sporsmal-tekster';

--- a/src/components/sporsmal/tilleggssporsmal/Egenmeldingsdager.tsx
+++ b/src/components/sporsmal/tilleggssporsmal/Egenmeldingsdager.tsx
@@ -89,6 +89,7 @@ const Egenmeldingsdager = ({ name, sykmeldingStartdato }: EgenmeldingsdagerProps
                                     placeholder="Trykk for å velge periode"
                                     onChange={datoer => oppdaterPeriode(periode.id, datoer)}
                                     options={{
+                                        position: 'below',
                                         minDate: new Date('10.02.2019'),
                                         maxDate: new Date('11.10.2019'),
                                         mode: 'range',

--- a/src/components/sporsmal/tilleggssporsmal/flatpickr.less
+++ b/src/components/sporsmal/tilleggssporsmal/flatpickr.less
@@ -1,5 +1,9 @@
 @import '../../../../node_modules/nav-frontend-core/less/_variabler.less';
 
+.flatpickr {
+    cursor: pointer;
+}
+
 .form-control .input {
     width: 100%;
     padding: 12px 20px;

--- a/src/components/sporsmal/tilleggssporsmal/flatpickr.less
+++ b/src/components/sporsmal/tilleggssporsmal/flatpickr.less
@@ -146,6 +146,8 @@
 
     &.arrowBottom {
         &:before {
+            transform: rotate(-225deg);
+            left: 44px;
             border-top-color: @navGra40;
         }
 

--- a/src/pages/TidslinjeSide.tsx
+++ b/src/pages/TidslinjeSide.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 import { Sidetittel } from 'nav-frontend-typografi';
 import Tekstomrade from 'nav-frontend-tekstomrade';
 import Brodsmuler, { Brodsmule } from '../components/brodsmuler/brodsmuler';

--- a/src/utils/sporsmal-utils.ts
+++ b/src/utils/sporsmal-utils.ts
@@ -1,7 +1,7 @@
 import { Sykmelding } from '../types/sykmeldingTypes';
 
 export const skalViseFrilansersporsmal = (sykmelding: Sykmelding, sykmeldingUtenforVentetid: boolean): boolean => {
-    const mulighetForArbeid = sykmelding.perioder.find(periode => !!periode.aktivitetIkkeMulig);
+    //const mulighetForArbeid = sykmelding.perioder.find(periode => !!periode.aktivitetIkkeMulig);
 
     // TODO: Rydd opp i (tilsynelatende) shady logikk fra sykefravear
     return !sykmeldingUtenforVentetid;


### PR DESCRIPTION
Fikser feil orientering på arrow når kalender er posisjonert over inputfelt.

Det er fortsatt feil "top" posisjon når kalenderen er posisjonert over. Top settes som style direkte på HTML-elementet av en js-funksjon, "positionCalendar", som ikke kan nås fra React. Får derfor ikke endret posisjon i less-filen.

`<div class="flatpickr-calendar rangeMode animate arrowTop open" tabindex="-1" style="top: 3900.23px; left: 32px; right: auto;">`

Foreløpig har jeg satt "position: 'below'" som option på flatpickr-komponenten for å unngå at den opnes over. Er ikke helt fornøyd med det som en permanent løsning (da det bla forutsetter at man har nok plass under)
