### PR TITLE
Remove all 'avbryt' logic outside of the form

### DIFF
--- a/client/src/pages/sykmelding/OK/APEN/AvbrytContext.tsx
+++ b/client/src/pages/sykmelding/OK/APEN/AvbrytContext.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, Dispatch, SetStateAction, useState } from 'react';
+
+interface AvbrytContext {
+    maAvbryte: boolean;
+    setMaAvbryte: Dispatch<SetStateAction<boolean>>;
+}
+
+export const AvbrytContext = createContext<AvbrytContext>({
+    maAvbryte: false,
+    setMaAvbryte: (): void => {
+        throw new Error('setMaAvbryte function must be overridden');
+    },
+});
+
+// Some answers in the OkApenSykmelding form implies that the sykmelding must "avbrytes"
+// This context makes it easier to set and pass this value across the component tree
+const AvbrytContextProvider: React.FC = ({ children }) => {
+    const [maAvbryte, setMaAvbryte] = useState(false);
+
+    return <AvbrytContext.Provider value={{ maAvbryte, setMaAvbryte }}>{children}</AvbrytContext.Provider>;
+};
+
+export default AvbrytContextProvider;

--- a/client/src/pages/sykmelding/OK/APEN/Form/Form.tsx
+++ b/client/src/pages/sykmelding/OK/APEN/Form/Form.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useContext } from 'react';
 import useForm from '../../../../commonComponents/hooks/useForm';
 import { Feiloppsummering } from 'nav-frontend-skjema';
 import { Knapp } from 'nav-frontend-knapper';
@@ -56,18 +56,8 @@ const Form: React.FC<FormProps> = ({ sykmelding }) => {
     const { mutate: bekreft, isLoading: isLoadingBekreft, error: errorBekreft } = useBekreft(sykmeldingId);
     const { mutate: send, isLoading: isLoadingSend, error: errorSend } = useSend(sykmeldingId);
 
-    const { maAvbryte, setMaAvbryte } = useContext(AvbrytContext);
+    const { maAvbryte } = useContext(AvbrytContext);
     const { formState, errors, setFormState, handleSubmit } = useForm<FormInputs>({ validationFunctions });
-
-    // TODO: refactor this...
-    useEffect(() => {
-        const skalAvbrytes = Boolean(
-            formState.feilaktigeOpplysninger?.some(
-                (opplysning) => opplysning === 'PERIODE' || opplysning === 'SYKMELDINGSGRAD_LAV',
-            ),
-        );
-        setMaAvbryte(skalAvbrytes);
-    }, [formState, setMaAvbryte]);
 
     const skalSendes = !!formState.valgtArbeidsgiver;
 
@@ -159,7 +149,7 @@ const Form: React.FC<FormProps> = ({ sykmelding }) => {
 
             {maAvbryte === false && (
                 <div className="margin-bottom--2 text--center">
-                    <Knapp spinner={isLoadingSend || isLoadingBekreft} type="hoved">
+                    <Knapp spinner={isLoadingSend || isLoadingBekreft} type="hoved" htmlType="submit">
                         {skalSendes ? 'Send' : 'Bekreft'} sykmelding
                     </Knapp>
                 </div>

--- a/client/src/pages/sykmelding/OK/APEN/Form/FormSections/BekreftOpplysninger.tsx
+++ b/client/src/pages/sykmelding/OK/APEN/Form/FormSections/BekreftOpplysninger.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { FormInputs, FeilaktigeOpplysninger } from '../../../../../../types/form';
 import { FeiloppsummeringFeil, RadioPanelGruppe, CheckboksPanelGruppe } from 'nav-frontend-skjema';
 import './FormSections.less';
@@ -6,6 +6,7 @@ import { Systemtittel } from 'nav-frontend-typografi';
 import FormInfoMessage from '../Components/FormInfoMessage';
 import FeilaktigeOpplysningerInfo from '../Components/FeilaktigeOpplysningerInfo';
 import { getUpdatedFeilaktigeOpplysninger } from '../../../../../../utils/formUtils';
+import { AvbrytContext } from '../../AvbrytContext';
 
 interface BekreftOpplysningerProps {
     formState: Partial<FormInputs>;
@@ -14,6 +15,8 @@ interface BekreftOpplysningerProps {
 }
 
 const BekreftOpplysninger = ({ formState, errors, setFormState }: BekreftOpplysningerProps) => {
+    const { setMaAvbryte } = useContext(AvbrytContext);
+
     return (
         <div className="form-section form-section--border">
             <Systemtittel className="margin-bottom--1">Bekreft opplysninger</Systemtittel>
@@ -103,6 +106,9 @@ const BekreftOpplysninger = ({ formState, errors, setFormState }: BekreftOpplysn
                                         updatedFeilaktigeOpplysninger.includes('PERIODE') ||
                                         updatedFeilaktigeOpplysninger.includes('SYKMELDINGSGRAD_LAV')
                                     ) {
+                                        // Open AvbrytPanel
+                                        setMaAvbryte(true);
+
                                         return {
                                             ...state,
                                             feilaktigeOpplysninger: updatedFeilaktigeOpplysninger,
@@ -113,6 +119,9 @@ const BekreftOpplysninger = ({ formState, errors, setFormState }: BekreftOpplysn
                                             harForsikring: undefined,
                                         };
                                     }
+
+                                    // Close AvbrytPanel
+                                    setMaAvbryte(false);
 
                                     return {
                                         ...state,

--- a/client/src/pages/sykmelding/OK/APEN/OkApenSykmelding.tsx
+++ b/client/src/pages/sykmelding/OK/APEN/OkApenSykmelding.tsx
@@ -24,75 +24,104 @@ import Veilederpanel from 'nav-frontend-veilederpanel';
 import VeilederMaleSvg from '../../../commonComponents/Veileder/svg/VeilederMaleSvg';
 import Form from './Form/Form';
 import PapirInfoheader from './PapirInfoheader';
+import useBrukerinformasjon from '../../../commonComponents/hooks/useBrukerinformasjon';
+import Spinner from '../../../commonComponents/Spinner/Spinner';
+import AvbrytContextProvider from './AvbrytContext';
+import AvbrytPanel from '../../components/AvbrytPanel/AvbrytPanel';
 
 interface OkApenSykmeldingProps {
     sykmelding: Sykmelding;
 }
 
 const OkApenSykmelding: React.FC<OkApenSykmeldingProps> = ({ sykmelding }) => {
+    const { isLoading, error, data: brukerinformasjon } = useBrukerinformasjon();
+
+    if (isLoading) {
+        return <Spinner headline="Henter brukerinformasjon" />;
+    }
+
+    if (error || brukerinformasjon === undefined) {
+        return <p>Det oppsto en feil da vi forsøkte å hente brukerinformasjon</p>;
+    }
+
+    const { diskresjonskode } = brukerinformasjon;
+
+    if (diskresjonskode === true) {
+        // TODO: return OkApenKode6Sykmelding
+    }
+
     return (
-        <div className="sykmelding-container">
-            <div className="margin-bottom--4">
-                <Veilederpanel kompakt fargetema="info" svg={<VeilederMaleSvg />}>
-                    Hei, her sjekker du opplysningene fra den som sykmeldte deg. Stemmer det med det dere ble enige om?
-                    Du velger selv om du vil bruke sykmeldingen.
-                </Veilederpanel>
-            </div>
-
-            {Boolean(sykmelding.papirsykmelding) && (
+        <AvbrytContextProvider>
+            <div className="sykmelding-container">
                 <div className="margin-bottom--4">
-                    <PapirInfoheader />
+                    <Veilederpanel kompakt fargetema="info" svg={<VeilederMaleSvg />}>
+                        Hei, her sjekker du opplysningene fra den som sykmeldte deg. Stemmer det med det dere ble enige
+                        om? Du velger selv om du vil bruke sykmeldingen.
+                    </Veilederpanel>
                 </div>
-            )}
 
-            {Boolean(sykmelding.egenmeldt) &&
-                // TODO: egenmeldt info
-                // finnes det egenmeldinger med status APEN?
-                null}
+                {Boolean(sykmelding.papirsykmelding) && (
+                    <div className="margin-bottom--4">
+                        <PapirInfoheader />
+                    </div>
+                )}
 
-            <div className="margin-bottom--2">
-                <SporsmalInfoheader />
-            </div>
+                {Boolean(sykmelding.egenmeldt) &&
+                    // TODO: egenmeldt info
+                    // finnes det egenmeldinger med status APEN?
+                    null}
 
-            <Sykmeldingsopplysninger id="sykmeldingsopplysninger" title="Opplysninger fra sykmeldingen">
-                <SykmeldingPerioder perioder={sykmelding.sykmeldingsperioder} />
-                <DiagnoseSeksjon diagnose={sykmelding.medisinskVurdering?.hovedDiagnose} />
-                {sykmelding.medisinskVurdering?.biDiagnoser.map((diagnose, index) => (
-                    <DiagnoseSeksjon key={index.toString()} diagnose={diagnose} isBidiagnose />
-                ))}
-                <FraverSeksjon fraver={sykmelding.medisinskVurdering?.annenFraversArsak} />
-                <SvangerskapSeksjon svangerskap={!!sykmelding.medisinskVurdering?.svangerskap} />
-                <SkadeSeksjon medisinskVurdering={sykmelding.medisinskVurdering} />
-                <ArbeidsuforSeksjon prognose={sykmelding.prognose} />
-                <PrognoseSeksjon prognose={sykmelding.prognose} />
-                <ArbeidsgiverSeksjon arbeidsgiver={sykmelding.arbeidsgiver} />
-                <LegeSeksjon navn={sykmelding.navnFastlege} />
+                <div className="margin-bottom--2">
+                    <SporsmalInfoheader />
+                </div>
 
-                <Sykmeldingsopplysninger
-                    id="flere-sykmeldingsopplysnigner"
-                    title="Flere opplysniger fra den som sykmeldte deg"
-                    type="FLERE_OPPLYSNINGER"
-                    expandedDefault={false}
-                >
-                    <BehandlingsDatoer
-                        behandletTidspunkt={sykmelding.behandletTidspunkt}
-                        syketilfelleStartDato={sykmelding.syketilfelleStartDato}
-                    />
-                    <MulighetForArbeid />
-                    <Friskmelding prognose={sykmelding.prognose} />
-                    <UtdypendeOpplysninger opplysninger={sykmelding.utdypendeOpplysninger} />
-                    <Arbeidsevne
-                        tiltakArbeidsplassen={sykmelding.tiltakArbeidsplassen}
-                        tiltakNAV={sykmelding.tiltakNAV}
-                    />
-                    <SeksjonMedTittel tittel="Annet">
-                        <ElementMedTekst margin tittel="Telefon til lege/sykmelder" tekst={sykmelding.behandler.tlf} />
-                    </SeksjonMedTittel>
+                <Sykmeldingsopplysninger id="sykmeldingsopplysninger" title="Opplysninger fra sykmeldingen">
+                    <SykmeldingPerioder perioder={sykmelding.sykmeldingsperioder} />
+                    <DiagnoseSeksjon diagnose={sykmelding.medisinskVurdering?.hovedDiagnose} />
+                    {sykmelding.medisinskVurdering?.biDiagnoser.map((diagnose, index) => (
+                        <DiagnoseSeksjon key={index.toString()} diagnose={diagnose} isBidiagnose />
+                    ))}
+                    <FraverSeksjon fraver={sykmelding.medisinskVurdering?.annenFraversArsak} />
+                    <SvangerskapSeksjon svangerskap={!!sykmelding.medisinskVurdering?.svangerskap} />
+                    <SkadeSeksjon medisinskVurdering={sykmelding.medisinskVurdering} />
+                    <ArbeidsuforSeksjon prognose={sykmelding.prognose} />
+                    <PrognoseSeksjon prognose={sykmelding.prognose} />
+                    <ArbeidsgiverSeksjon arbeidsgiver={sykmelding.arbeidsgiver} />
+                    <LegeSeksjon navn={sykmelding.navnFastlege} />
+
+                    <Sykmeldingsopplysninger
+                        id="flere-sykmeldingsopplysnigner"
+                        title="Flere opplysniger fra den som sykmeldte deg"
+                        type="FLERE_OPPLYSNINGER"
+                        expandedDefault={false}
+                    >
+                        <BehandlingsDatoer
+                            behandletTidspunkt={sykmelding.behandletTidspunkt}
+                            syketilfelleStartDato={sykmelding.syketilfelleStartDato}
+                        />
+                        <MulighetForArbeid />
+                        <Friskmelding prognose={sykmelding.prognose} />
+                        <UtdypendeOpplysninger opplysninger={sykmelding.utdypendeOpplysninger} />
+                        <Arbeidsevne
+                            tiltakArbeidsplassen={sykmelding.tiltakArbeidsplassen}
+                            tiltakNAV={sykmelding.tiltakNAV}
+                        />
+                        <SeksjonMedTittel tittel="Annet">
+                            <ElementMedTekst
+                                margin
+                                tittel="Telefon til lege/sykmelder"
+                                tekst={sykmelding.behandler.tlf}
+                            />
+                        </SeksjonMedTittel>
+                    </Sykmeldingsopplysninger>
                 </Sykmeldingsopplysninger>
-            </Sykmeldingsopplysninger>
 
-            <Form sykmelding={sykmelding} />
-        </div>
+                <Form sykmelding={sykmelding} />
+
+                {/* Avbryt component */}
+                <AvbrytPanel />
+            </div>
+        </AvbrytContextProvider>
     );
 };
 

--- a/client/src/pages/sykmelding/OK/APEN/PapirInfoheader.tsx
+++ b/client/src/pages/sykmelding/OK/APEN/PapirInfoheader.tsx
@@ -47,6 +47,7 @@ const PapirInfoheader = () => {
                     </Knapp>
                 </>
             )}
+
             {harGittVidere === false && (
                 <>
                     <Normaltekst tag="p" className="margin-bottom--2">

--- a/client/src/pages/sykmelding/OK/APEN/PapirInfoheader.tsx
+++ b/client/src/pages/sykmelding/OK/APEN/PapirInfoheader.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
 import { Innholdstittel, Normaltekst, Element } from 'nav-frontend-typografi';
 import { RadioPanelGruppe } from 'nav-frontend-skjema';
-import AvbrytPanel from '../../components/AvbrytPanel/AvbrytPanel';
 import { Knapp } from 'nav-frontend-knapper';
+import useAvbryt from '../../../commonComponents/hooks/useAvbryt';
+import { useParams } from 'react-router-dom';
 
 const PapirInfoheader = () => {
+    const { sykmeldingId } = useParams();
+    const { isLoading, mutate: avbryt } = useAvbryt(sykmeldingId);
+
     const [harGittVidere, setHarGittVidere] = useState<boolean | undefined>(undefined);
-    const [skalAvbrytes, setSkalAvbrytes] = useState<boolean>(false);
 
     return (
         <>
@@ -28,10 +31,8 @@ const PapirInfoheader = () => {
                 onChange={(_event, value) => {
                     if (value === 'Ja') {
                         setHarGittVidere(true);
-                        setSkalAvbrytes(true);
                     } else {
                         setHarGittVidere(false);
-                        setSkalAvbrytes(false);
                     }
                 }}
             />
@@ -41,6 +42,9 @@ const PapirInfoheader = () => {
                     <Normaltekst tag="p" className="margin-bottom--1">
                         Da avbryter du den digitale sykmeldingen.
                     </Normaltekst>
+                    <Knapp className="margin-bottom--2" spinner={isLoading} onClick={() => avbryt()}>
+                        Avbryt den digitale sykmeldingen
+                    </Knapp>
                 </>
             )}
             {harGittVidere === false && (
@@ -57,12 +61,11 @@ const PapirInfoheader = () => {
                     </a>
 
                     <Element className="margin-bottom--1">Hvis du i stedet skal fortsette med papiret:</Element>
-                    <Knapp className="margin-bottom--2" onClick={() => setSkalAvbrytes(true)}>
+                    <Knapp className="margin-bottom--2" spinner={isLoading} onClick={() => avbryt()}>
                         Avbryt den digitale sykmeldingen
                     </Knapp>
                 </>
             )}
-            {skalAvbrytes && <AvbrytPanel type="PAPER" avbrytSykmelding={() => {}} closePanel={setSkalAvbrytes} />}
         </>
     );
 };

--- a/client/src/pages/sykmelding/OK/AVBRUTT/OkAvbruttSykmelding.tsx
+++ b/client/src/pages/sykmelding/OK/AVBRUTT/OkAvbruttSykmelding.tsx
@@ -42,7 +42,7 @@ const OkAvbruttSykmelding: React.FC<OkAvbruttSykmeldingProps> = ({ sykmelding })
                         Dato avbrutt: {dayjs(sykmelding.sykmeldingStatus.timestamp).format('dddd D. MMMM, kl. HH:mm')}
                     </EtikettLiten>
                 </AlertStripe>
-                <Knapp spinner={isLoading} onClick={() => gjenapne()}>
+                <Knapp spinner={isLoading} disabled={isLoading} onClick={() => gjenapne()}>
                     Bruk sykmeldingen
                 </Knapp>
                 {error && <AlertStripeFeil>Det oppsto en feil ved gjenåpning av sykmeldingen</AlertStripeFeil>}

--- a/client/src/pages/sykmelding/OK/BEKREFTET/OkBekreftetSykmelding.tsx
+++ b/client/src/pages/sykmelding/OK/BEKREFTET/OkBekreftetSykmelding.tsx
@@ -19,12 +19,20 @@ import UtdypendeOpplysninger from '../../components/Sykmeldingsopplysninger/utdy
 import { Sykmelding } from '../../../../types/sykmelding';
 import Statuspanel from '../../components/Statuspanel/Statuspanel';
 import Sykmeldingsopplysninger from '../../components/Sykmeldingsopplysninger/Sykmeldingsopplysninger';
+import { useParams } from 'react-router-dom';
+import useGjenapne from '../../../commonComponents/hooks/useGjenapne';
+import { Knapp } from 'nav-frontend-knapper';
+import { AlertStripeFeil } from 'nav-frontend-alertstriper';
+import { Undertittel } from 'nav-frontend-typografi';
 
 interface OkBekreftetSykmeldingProps {
     sykmelding: Sykmelding;
 }
 
 const OkBekreftetSykmelding: React.FC<OkBekreftetSykmeldingProps> = ({ sykmelding }) => {
+    const { sykmeldingId } = useParams();
+    const { mutate: gjenapne, isLoading, error } = useGjenapne(sykmeldingId);
+
     return (
         <div className="sykmelding-container">
             <Statuspanel
@@ -32,6 +40,14 @@ const OkBekreftetSykmelding: React.FC<OkBekreftetSykmeldingProps> = ({ sykmeldin
                 erEgenmeldt={sykmelding.egenmeldt}
                 avventendeSykmelding={sykmelding.sykmeldingsperioder.some((periode) => periode.type === 'AVVENTENDE')}
             />
+
+            <div style={{ marginBottom: '2rem', textAlign: 'center' }}>
+                <Undertittel style={{ marginBottom: '1rem' }}>Fylte du ut feil opplysninger?</Undertittel>
+                <Knapp spinner={isLoading} disabled={isLoading} onClick={() => gjenapne()}>
+                    gjør utfyllingen på nytt
+                </Knapp>
+                {error && <AlertStripeFeil>Det oppsto en feil ved gjenåpning av sykmeldingen</AlertStripeFeil>}
+            </div>
 
             <Sykmeldingsopplysninger id="flere-sykmeldingsopplysnigner" title="Opplysninger fra sykmeldingen">
                 <SykmeldingPerioder perioder={sykmelding.sykmeldingsperioder} />

--- a/client/src/pages/sykmelding/components/AvbrytPanel/AvbrytPanel.tsx
+++ b/client/src/pages/sykmelding/components/AvbrytPanel/AvbrytPanel.tsx
@@ -1,88 +1,67 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import './AvbrytPanel.less';
 import { Xknapp } from 'nav-frontend-ikonknapper';
 import { Normaltekst } from 'nav-frontend-typografi';
 import { Knapp } from 'nav-frontend-knapper';
+import { AvbrytContext } from '../../OK/APEN/AvbrytContext';
+import useAvbryt from '../../../commonComponents/hooks/useAvbryt';
+import { useParams } from 'react-router-dom';
 
-interface AvbrytPanelProps {
-    avbrytSykmelding: () => void;
-    closePanel: React.Dispatch<React.SetStateAction<boolean>>;
-    type?: 'NORMAL' | 'PAPER' | 'MANDATORY_CANCEL';
-    showLoadingSpinner?: boolean;
-}
-const AvbrytPanel = ({
-    avbrytSykmelding,
-    closePanel,
-    type = 'NORMAL',
-    showLoadingSpinner = false,
-}: AvbrytPanelProps) => {
-    const MainContent: JSX.Element = (() => {
-        switch (type) {
-            case 'NORMAL':
-                return (
-                    <>
-                        <Normaltekst>Er du sikker på at du vil avbryte sykmeldingen?</Normaltekst>
-                        <br />
-                        <Knapp
-                            htmlType="button"
-                            type="fare"
-                            spinner={showLoadingSpinner}
-                            onClick={() => avbrytSykmelding()}
-                        >
-                            Ja, jeg er sikker
-                        </Knapp>
-                    </>
-                );
-            case 'PAPER':
-                return (
-                    <>
-                        <Normaltekst>Er du sikker på at du skal fortsette med papir?</Normaltekst>
-                        <br />
-                        <Normaltekst>Du avbryter kun den digitale sykmeldingen.</Normaltekst>
-                        <br />
-                        <Knapp
-                            htmlType="button"
-                            type="fare"
-                            spinner={showLoadingSpinner}
-                            onClick={() => avbrytSykmelding()}
-                        >
-                            Ja, jeg er sikker
-                        </Knapp>
-                    </>
-                );
-            case 'MANDATORY_CANCEL':
-                return (
-                    <>
-                        <Knapp
-                            htmlType="button"
-                            type="fare"
-                            className="margin-bottom--2"
-                            spinner={showLoadingSpinner}
-                            onClick={() => avbrytSykmelding()}
-                        >
-                            Avbryt sykmelding
-                        </Knapp>
-                        <br />
-                        <Normaltekst>
-                            Selv om du avbryter sykmeldingen nå, har du mulighet til å gjenåpne den på et senere
-                            tidspunkt.
-                        </Normaltekst>
-                    </>
-                );
-        }
-    })();
+const AvbrytPanel: React.FC = () => {
+    const { sykmeldingId } = useParams();
+
+    // maAvbryte overrules isOpen
+    const { maAvbryte } = useContext(AvbrytContext);
+    const [isOpen, setIsOpen] = useState(false);
+
+    // TODO: error state
+    const { isLoading, mutate: avbryt } = useAvbryt(sykmeldingId);
+
+    if (maAvbryte) {
+        return (
+            <div className="avbryt-panel">
+                <Knapp
+                    htmlType="button"
+                    type="fare"
+                    className="margin-bottom--2"
+                    spinner={isLoading}
+                    onClick={() => avbryt()}
+                >
+                    Avbryt sykmelding
+                </Knapp>
+                <br />
+                <Normaltekst>
+                    Selv om du avbryter sykmeldingen nå, har du mulighet til å gjenåpne den på et senere tidspunkt.
+                </Normaltekst>
+            </div>
+        );
+    }
 
     return (
-        <div className="avbryt-panel">
-            {type !== 'MANDATORY_CANCEL' && (
-                <Xknapp
-                    htmlType="button"
-                    className="avbryt-panel__cross"
-                    onClick={() => closePanel((previousValue) => !previousValue)}
-                />
+        <>
+            <div className="avbryt-toggle" style={{ textAlign: 'center', marginBottom: '1rem' }}>
+                <Knapp mini onClick={() => setIsOpen((prev) => !prev)}>
+                    Jeg ønsker ikke å bruke denne sykmeldingen
+                </Knapp>
+            </div>
+
+            {isOpen && (
+                <div className="avbryt-panel">
+                    {maAvbryte === false && (
+                        <Xknapp
+                            htmlType="button"
+                            className="avbryt-panel__cross"
+                            onClick={() => setIsOpen((prev) => !prev)}
+                        />
+                    )}
+                    <Normaltekst>Er du sikker på at du vil avbryte sykmeldingen?</Normaltekst>
+                    <br />
+                    <Knapp htmlType="button" type="fare" spinner={isLoading} onClick={() => avbryt()}>
+                        Ja, jeg er sikker
+                    </Knapp>
+                </div>
             )}
-            {MainContent}
-        </div>
+        </>
     );
 };
 

--- a/client/src/pages/sykmeldinger/SykmeldingerPage.tsx
+++ b/client/src/pages/sykmeldinger/SykmeldingerPage.tsx
@@ -5,7 +5,6 @@ import Spinner from '../commonComponents/Spinner/Spinner';
 import LenkepanelContainer from './components/LenkepanelContainer';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import Lenke from 'nav-frontend-lenker';
-import TilHovedsiden from '../commonComponents/TilHovedsiden/TilHovedsiden';
 import useSykmeldinger from '../commonComponents/hooks/useSykmeldinger';
 import SykmeldingerPageWrapper from './components/SykmeldingerPageWrapper';
 
@@ -45,7 +44,6 @@ const SykmeldingerPage: React.FC = () => {
                 </Lenke>
             </Ekspanderbartpanel>
             <LenkepanelContainer type="TIDLIGERE_SYKMELDINGER" sykmeldinger={pastSykmeldinger} />
-            <TilHovedsiden />
         </SykmeldingerPageWrapper>
     );
 };


### PR DESCRIPTION
Synes ikke Avbryting av sykmedlingen trenger å være på innsiden av form-komponenten. Trekker den ut, og bruker en context for å bestemme om avbrytpanelet MÅ vises